### PR TITLE
Make the plugin work with newer versions of astroid.

### DIFF
--- a/pylint_sqlalchemy/plugin.py
+++ b/pylint_sqlalchemy/plugin.py
@@ -15,7 +15,7 @@ def register(linter):
 def handle_session(cls):
     """Handle the sqlalchemy.orm.scoping.scoped_session."""
     if cls.name == 'scoped_session':
-        source_files = cls.parent.source_file.split('/')
+        source_files = cls.parent.file.split('/')
         source_files[-1] = 'session.py'
         module = AstroidBuilder(MANAGER).file_build(
             '/'.join(source_files), 'sqlalchemy.orm.session'
@@ -27,4 +27,4 @@ def handle_session(cls):
         return cls
 
 
-MANAGER.register_transform(astroid.Class, handle_session)
+MANAGER.register_transform(astroid.ClassDef, handle_session)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ SHORT_DESC = ('pylint-sqlalchemy is a Pylint plugin for improving code'
 
 REQUIRES = [
     'SQLAlchemy',
-    'pylint >= 1.6'
+    'pylint >= 1.6',
+    'astroid >= 1.5',
 ]
 
 TESTS_REQUIRES = [


### PR DESCRIPTION
`astroid.Class` has been renamed to `astroid.ClassDef` with astroid 1.5 in 2015. Newer versions (I guess 2.0) dropped the legacy alias. This PR makes the plugin work with those versions.